### PR TITLE
[Android] Feature/chat-error

### DIFF
--- a/src/mobile/android/app/src/main/java/com/plop/plopmessenger/data/remote/stomp/WebSocketListener.kt
+++ b/src/mobile/android/app/src/main/java/com/plop/plopmessenger/data/remote/stomp/WebSocketListener.kt
@@ -124,8 +124,12 @@ class WebSocketListener @Inject constructor(
             } else {
                 updateChatRoom(message.chatroomId, message.content)
             }
+            try {
+                messageRepository.insertMessage(message)
+            }catch (e: Exception) {
+                Log.d("SaveMessage", e.message.toString())
+            }
             saveMembers(memberId = message.messageFromID, message.chatroomId, message)
-            messageRepository.insertMessage(message)
         }
 
     }
@@ -151,7 +155,7 @@ class WebSocketListener @Inject constructor(
                     chatroomId = chatRoomId,
                     nickname = "",
                     profileImg = "",
-                    readMessage = message.messageId
+                    readMessage = null
                 )
             )
         } catch (e: Exception) {

--- a/src/mobile/android/app/src/main/java/com/plop/plopmessenger/domain/usecase/chatroom/GetRemoteChatRoomUseCase.kt
+++ b/src/mobile/android/app/src/main/java/com/plop/plopmessenger/domain/usecase/chatroom/GetRemoteChatRoomUseCase.kt
@@ -1,15 +1,18 @@
 package com.plop.plopmessenger.domain.usecase.chatroom
 
 import android.util.Log
+import com.plop.plopmessenger.data.dto.response.toMember
 import com.plop.plopmessenger.data.local.entity.toChatRoom
 import com.plop.plopmessenger.domain.repository.ChatRoomRepository
+import com.plop.plopmessenger.domain.repository.MemberRepository
 import com.plop.plopmessenger.domain.util.Resource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class GetRemoteChatRoomUseCase @Inject constructor(
-    private val chatRoomRepository: ChatRoomRepository
+    private val chatRoomRepository: ChatRoomRepository,
+    private val memberRepository: MemberRepository
 ) {
     suspend operator fun invoke(): Resource<Boolean> {
         try {
@@ -21,6 +24,11 @@ class GetRemoteChatRoomUseCase @Inject constructor(
                         chatRoomRepository.insertAllChatRoom(
                             chatrooms?.getMyRoomDto?.map { it.toChatRoom() } ?: emptyList()
                         )
+                        chatrooms?.getMyRoomDto?.forEach {
+                            memberRepository.insertAllMember(
+                                it.members.map { member -> member.toMember(it.roomId) }
+                            )
+                        }
                     } else {
 
                     }


### PR DESCRIPTION
[Fix]: fix message error 

1. 멤버를 넣을 시 FOREIGEN ERROR 뜨는 문제
- 원인 : save member를 할 때 마지막으로 읽은 메세지(=방금 전송된 메세지)를 넣게 되는데 그 메세지를 넣기도 전에 member를 넣으려고 하니 메세지의 아이디가 존재하지 않아서 발생하는 이슈
- 해결방안 : savemember를 save message뒤에 넣어줬다. 
- 만약 새로온 member가 보낼경우는? : Enter의 경우 따로 처리해줄 예정이라 괜찮을 것 같다.

2. 메세지를 넣을 시 FOREIGEN ERROR 뜨는 문제
- 원인: 앱 첫 시작 후 해당 채팅방에 안들어가면 그 채팅방 member에 대한 정보도 받아올 수 없어서 parent 로 할 member key가 없다. 이로인해 메세지도 넣지 못하게 된다. 
- 해결방안 : get remote chat room 할 때 member도 넣어준다.