### PR TITLE
[Backend] Feature/profile

### DIFF
--- a/src/server/user/src/main/resources/application.yml
+++ b/src/server/user/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
   redis:
     host: 127.0.0.1
     port: 6379
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 eureka:
   instance:


### PR DESCRIPTION
feat: Extends maximum file size
기본 서블릿 파일 전송 크기 제한 : 1 MB -> 10MB로 수정